### PR TITLE
add module export

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,4 +5,6 @@
   if(global.alert) {
     alert('aarrr');
   }
+  if(global.module !== undefined)
+    module.exports = 'aarrr';
 })(this);


### PR DESCRIPTION
That way, we can use `require('aarrr')` to get the plain string `aarrr`. Isn't that good? AARRR!
